### PR TITLE
DTrace for Python

### DIFF
--- a/python/call_stack.d
+++ b/python/call_stack.d
@@ -1,0 +1,41 @@
+self int indent;
+
+python$target:::function-entry
+/copyinstr(arg0) == "program.py"/
+{
+        self->trace = 1;
+}
+
+python$target:::function-entry
+/self->trace/
+{
+        printf("%d\t%*s:", timestamp, 15, probename);
+        printf("%*s", self->indent, "");
+        printf("%s:%s:%d\n", basename(copyinstr(arg0)), copyinstr(arg1), arg2);
+        self->indent++;
+}
+
+python$target:::function-return
+/self->trace/
+{
+        self->indent--;
+        printf("%d\t%*s:", timestamp, 15, probename);
+        printf("%*s", self->indent, "");
+        printf("%s:%s:%d\n", basename(copyinstr(arg0)), copyinstr(arg1), arg2);
+}
+
+python$target:::function-return
+/copyinstr(arg0) == "program.py"/
+{
+        self->trace = 0;
+}
+
+python$target:::line
+/*
+/copyinstr(arg0) == "program.py"/
+*/
+{
+        printf("%d\t%*s:", timestamp, 15, probename);
+        printf("%*s", self->indent, "");
+        printf("%s:%s:%d\n", basename(copyinstr(arg0)), copyinstr(arg1), arg2);
+}


### PR DESCRIPTION
[DTrace](https://docs.python.org/3/howto/instrumentation.html)

**This requires building Python with `--with-dtrace` option.** This is not enabled by default and you will need to compile Python from source, this applies to Docker images as well.